### PR TITLE
Fix #130 that domain validation fails when subdomain name contains IP address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## FIWARE Big Bang v0.9.0-next
 
+-   Fix issue #130 that domain validation fails when subdomain name contains IP address (#131)
 -   Update GitHub Actions (#129)
 -   Update copyright (#128)
 -   Update feature for creating app cert (#127)

--- a/lets-fiware.sh
+++ b/lets-fiware.sh
@@ -952,7 +952,7 @@ validate_domain() {
     if [ -n "${val}" ]; then
         logging_info "Sub-domain: ${val}"
         # shellcheck disable=SC2086
-        IP=$(${HOST_CMD} -4 ${val} | awk 'match($0,/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/) { print substr($0, RSTART, RLENGTH) }' || true)
+        IP=$(${HOST_CMD} -4 ${val} | sed -n -r "/ has address /s/^.* has address ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+).*$/\1/p" || true)
         if [ "$IP" = "" ]; then
           IP=$(sed -n -e "/${val}/s/\([^ ].*\) .*/\1/p" /etc/hosts)
         fi


### PR DESCRIPTION
## Proposed changes

This PR fixes issue #130 that domain validation fails when subdomain name contains IP address.

```
$ host -4 orion.example.com
orion.example.com is an alias for ip-192.168.0.1.example.com.
ip-192.168.0.1.example.com has address 192.168.0.1
```

```
$host -4 orion.example.com | sed -n -r "/ has address /s/^.* has address ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+).*$/\1/p"
192.168.0.1
```

Cc: @kikuzo

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/FIWARE-Big-Bang-individual-cla.pdf)
-   [ ] I have updated the change log (CHANGELOG.md)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A