### PR TITLE
Fix #153 that incorrect http root path when deploying multi-instance for Node-RED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## FIWARE Big Bang v0.10.0-next
 
+-   Fix issue #153 that incorrect http root path when deploying multi-instance for Node-RED (#154)
 -   Fix typos (#152)
 -   Update Node-RED to 2.2.0 (#151)
 -   Update Orion to 3.5.1 (#148)

--- a/config.sh
+++ b/config.sh
@@ -311,9 +311,11 @@ NODE_RED_INSTANCE_NUMBER=
 NODE_RED_INSTANCE_USERNAME=
 
 # httpNodeRoot for Node-RED instance. default: / or /node-red???
+#   Must be a path starting with '/'
 NODE_RED_INSTANCE_HTTP_NODE_ROOT=
 
 # httpAdminRoot for Node-RED instance. default: / or /node-red???
+#   Must be a path starting with '/'
 NODE_RED_INSTANCE_HTTP_ADMIN_ROOT=
 
 # Logging level for Node-RED

--- a/docs/installation/node-red.md
+++ b/docs/installation/node-red.md
@@ -17,12 +17,15 @@
 
 You can specify configurations by editing the `config.sh` file.
 
-| Variable name                   | Description                      | Default value |
-| ------------------------------- | -------------------------------- | ------------- |
-| NODE\_RED                       | A sub-domain name of Node-RED    | (empty)       |
-| NODE\_RED\_INSTANCE\_NUMBER     | Number of Node-RED instance.     | 1             |
-| NODE\_RED\_INSTANCE\_USERNAME   | Username for Node-RED instance.  | node-red      |
-| NODE\_RED\_INSTANCE\_HTTP\_ROOT | HTTP root for Node-RED instance. | /node-red     |
+| Variable name                          | Description                                                           | Default value                      |
+| -------------------------------------- | --------------------------------------------------------------------- | ---------------------------------- |
+| NODE\_RED                              | A sub-domain name of Node-RED                                         | (empty)                            |
+| NODE\_RED\_INSTANCE\_NUMBER            | Number of Node-RED instance.                                          | 1                                  |
+| NODE\_RED\_INSTANCE\_USERNAME          | Username for Node-RED instance.                                       | node-red                           |
+| NODE\_RED\_INSTANCE\_HTTP\_ROOT        | HTTP root for Node-RED instance. Must be a path starting with '/'     | / (single) or /node-red??? (multi) |
+| NODE\_RED\_INSTANCE\_HTTP\_ADMIN\_ROOT | httpAdminRoot for Node-RED instance. Must be a path starting with '/' | / (single) or /node-red??? (multi) |
+| NODE\_RED\_LOGGING\_LEVEL              | Logging level for Node-RED instance.                                  | Logging level for Node-RED         |
+| NODE\_RED\_LOGGING\_METRICS            | Logging metrics for Node-RED instance.                                | (empty)                            |
 
 ## How to setup
 
@@ -56,6 +59,13 @@ https://node-red.example.com/node-red003        node-red003@example.com W1XEgeJj
 https://node-red.example.com/node-red004        node-red004@example.com jdZV5SGXEZbtGjTP
 https://node-red.example.com/node-red005        node-red005@example.com XgnFHj63gqxfqyE1
 ```
+
+#### HTTP root value for Multi-instance
+
+| NODE\_RED\_INSTANCE\_HTTP\_ROOT | HTTP root         | Example                   |
+| ------------------------------- | ----------------- | ------------------------- |
+| (empty)                         | /node-red???/     | /node-red???/worldmap     |
+| /abc                            | /node-red???/abc/ | /node-red???/abc/worldmap |
 
 ## Related information
 

--- a/lets-fiware.sh
+++ b/lets-fiware.sh
@@ -2844,7 +2844,7 @@ EOF
   for i in $(seq "${NODE_RED_INSTANCE_NUMBER}")
   do
     number=$(printf "%03d" "$i")
-    http_node_root=${NODE_RED_INSTANCE_HTTP_NODE_ROOT}${number}
+    http_node_root=${NODE_RED_INSTANCE_HTTP_ADMIN_ROOT}${number}${NODE_RED_INSTANCE_HTTP_NODE_ROOT}
     http_admin_root=${NODE_RED_INSTANCE_HTTP_ADMIN_ROOT}${number}
     username=${NODE_RED_INSTANCE_USERNAME}${number}
     env_val=NODE_RED_${number}_


### PR DESCRIPTION
## Proposed changes

This PR fixes issue #153 that incorrect http root path when deploying multi-instance for Node-RED.

Cc: @kikuzo

| NODE\_RED\_INSTANCE\_HTTP\_ROOT |  HTTP root            | Example                   |
| ------------------------------- | ---------------- | ------------------------- |
| (empty)                         | /node-red???/     | /node-red???/worldmap     |
| /abc                            | /node-red???/abc/ | /node-red???/abc/worldmap |

Open the worldmap at https://node-red.example.com/node-red001/worldmap.

![node-3](https://user-images.githubusercontent.com/31051904/153374219-c9ffc2f1-1bb8-4240-9024-1dba7eaf7038.png)

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/FIWARE-Big-Bang-individual-cla.pdf)
-   [X] I have updated the change log (CHANGELOG.md)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A