### PR TITLE
Fix invalid URL escape in get_token.sh (#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## FIWARE Big Bang v0.20.0-next
 
+-   Fix invalid URL escape in get_token.sh (#232)
 -   Add feature to create ngsi go environment (#229)
 -   Add init flag to IoT Agent and Comet (#228)
 -   Add init flag to Keyrock and Wilma (#227)

--- a/setup/script/get_token.sh
+++ b/setup/script/get_token.sh
@@ -38,4 +38,4 @@ fi
 
 . ./.env
 
-curl -sS "https://${KEYROCK}/token" --data "username=${IDM_ADMIN_EMAIL}" --data "password=${IDM_ADMIN_PASS}" | jq -r .access_token
+curl -sS "https://${KEYROCK}/token" --data "{\"username\": \"${IDM_ADMIN_EMAIL}\", \"password\": \"${IDM_ADMIN_PASS}\"}" --header "Content-Type: application/json" | jq -r .access_token


### PR DESCRIPTION
## Proposed changes

This PR fixes invalid URL escape in get_token.sh.

```
{"error":"tokeProxyRequestToken004 invalid URL escape "%%m""}
```

The reason for this error is that the `%` in the password was parsed as a URL escape while sending the request with `Content-Type: application/x-www-form-urlencoded`.


## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update docker image version of FIWARE GE.
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/FIWARE-Big-Bang-individual-cla.pdf)
-   [X] I have updated the change log (CHANGELOG.md)
-   [X] I send this pull request to the `v0.20.0-next` branch.
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...
