### PR TITLE
Bump: 0.28.0-next -> 0.29.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
 If it fixes a bug or resolves a feature request, be sure to link to that issue. Please send a pull request to
-the `v0.28.0-next` branch.
+the `v0.29.0-next` branch.
 
 ## Types of changes
 
@@ -23,7 +23,7 @@ merging your code._
 -   [ ] I have read the [CONTRIBUTING](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/CONTRIBUTING.md) doc
 -   [ ] I have signed the [CLA](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/FIWARE-Big-Bang-individual-cla.pdf)
 -   [ ] I have updated the change log (CHANGELOG.md)
--   [ ] I send this pull request to the `v0.28.0-next` branch.
+-   [ ] I send this pull request to the `v0.29.0-next` branch.
 -   [ ] I have added tests that prove my fix is effective or that my feature works
 -   [ ] I have added necessary documentation (if appropriate)
 -   [ ] Any dependent changes have been merged and published in downstream modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## FIWARE Big Bang v0.28.0-next
+## FIWARE Big Bang v0.29.0 - 19 July, 2023
 
 -   FIX cert renew error (#287)
 -   FIX cert renew error (#286)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ If you don't see your idea listed, and you think it fits into the goals of this 
 -   **If your contribution is minor,** such as a typo fix, open a pull request.
 -   **If your contribution is major,** such as a new guide, start by opening an issue first. That way, other people can
     weigh in on the discussion before you do any work.
--   Send a pull request to the `v0.28.0-next` branch (not main branch).
+-   Send a pull request to the `v0.29.0-next` branch (not main branch).
 
 ## Community
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -83,13 +83,13 @@ FI-BB は FIWARE Big Bang の略名です。
 FIWARE Big Bang の tar.gz ファイルをダウンロードします。
 
 ```bash
-curl -sL https://github.com/lets-fiware/FIWARE-Big-Bang/archive/refs/tags/v0.28.0.tar.gz | tar zxf -
+curl -sL https://github.com/lets-fiware/FIWARE-Big-Bang/archive/refs/tags/v0.29.0.tar.gz | tar zxf -
 ```
 
-`FIWARE-Big-Bang-0.28.0` ディレクトリに移動します。
+`FIWARE-Big-Bang-0.29.0` ディレクトリに移動します。
 
 ```bash
-cd FIWARE-Big-Bang-0.28.0/
+cd FIWARE-Big-Bang-0.29.0/
 ```
 
 独自のドメイン名とパブリック IP アドレスを指定して、`lets-fiware.sh` スクリプトを実行します。

--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ or CNAME records.
 Download a tar.gz file for the FIWARE Big Bang.
 
 ```bash
-curl -sL https://github.com/lets-fiware/FIWARE-Big-Bang/archive/refs/tags/v0.28.0.tar.gz | tar zxf -
+curl -sL https://github.com/lets-fiware/FIWARE-Big-Bang/archive/refs/tags/v0.29.0.tar.gz | tar zxf -
 ```
 
-Move to the `FIWARE-Big-Bang-0.28.0` directory.
+Move to the `FIWARE-Big-Bang-0.29.0` directory.
 
 ```bash
-cd FIWARE-Big-Bang-0.28.0/
+cd FIWARE-Big-Bang-0.29.0/
 ```
 
 Run the `lets-fiware.sh` script with your own domain name and a public IP address.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 0.28.0   | :white_check_mark: |
-| < 0.28.0 | :x:                |
+| 0.29.0   | :white_check_mark: |
+| < 0.29.0 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-VERSION=0.28.0-next
+VERSION=0.29.0

--- a/config.sh
+++ b/config.sh
@@ -30,7 +30,7 @@ IDM_DEBUG=false
 IMAGE_KEYROCK=letsfiware/idm:8.1.0
 
 # Docker image for Postfix
-IMAGE_POSTFIX=letsfiware/postfix:0.28.0-next
+IMAGE_POSTFIX=letsfiware/postfix:0.29.0
 
 #
 # Wilma
@@ -325,7 +325,7 @@ NODE_RED_LOGGING_METRICS=
 NODE_RED_LOGGING_AUDIT=
 
 # Docker image for Node-RED
-IMAGE_NODE_RED=letsfiware/node-red:0.28.0-next
+IMAGE_NODE_RED=letsfiware/node-red:0.29.0
 
 #
 # Grafana
@@ -351,7 +351,7 @@ ZEPPELIN=
 ZEPPELIN_DEBUG=
 
 # Docker image for Zeppelin
-IMAGE_ZEPPELIN=letsfiware/zeppelin:0.28.0-next
+IMAGE_ZEPPELIN=letsfiware/zeppelin:0.29.0
 
 #
 # Queryproxy
@@ -363,7 +363,7 @@ QUERYPROXY=
 QUERYPROXY_LOGLEVEL=info
 
 # Docker image for Queryproxy
-IMAGE_QUERYPROXY=letsfiware/queryproxy:0.28.0-next
+IMAGE_QUERYPROXY=letsfiware/queryproxy:0.29.0
 
 #
 # Tokenproxy
@@ -375,7 +375,7 @@ TOKENPROXY_LOGLEVEL=info
 TOKENPROXY_VERBOSE=
 
 # Docker image for Tokenproxy
-IMAGE_TOKENPROXY=letsfiware/tokenproxy:0.28.0-next
+IMAGE_TOKENPROXY=letsfiware/tokenproxy:0.29.0
 
 #
 # Regproxy
@@ -414,7 +414,7 @@ REGPROXY_LOGLEVEL=info
 REGPROXY_VERBOSE=false
 
 # Docker image for Regproxy
-IMAGE_REGPROXY=letsfiware/regproxy:0.28.0-next
+IMAGE_REGPROXY=letsfiware/regproxy:0.29.0
 
 #
 # MongoDB

--- a/docs/en/installation/index.md
+++ b/docs/en/installation/index.md
@@ -86,13 +86,13 @@ or CNAME records.
 Download a tar.gz file for the FIWARE Big Bang.
 
 ```bash
-curl -sL https://github.com/lets-fiware/FIWARE-Big-Bang/archive/refs/tags/v0.28.0.tar.gz | tar zxf -
+curl -sL https://github.com/lets-fiware/FIWARE-Big-Bang/archive/refs/tags/v0.29.0.tar.gz | tar zxf -
 ```
 
-Move to the `FIWARE-Big-Bang-0.28.0` directory.
+Move to the `FIWARE-Big-Bang-0.29.0` directory.
 
 ```bash
-cd FIWARE-Big-Bang-0.28.0/
+cd FIWARE-Big-Bang-0.29.0/
 ```
 
 Run the `lets-fiware.sh` script with your own domain name and a public IP address.

--- a/docs/ja/installation/index.md
+++ b/docs/ja/installation/index.md
@@ -94,13 +94,13 @@ FIWARE Big Bang によってインストールされた Web アプリケーシ�
 FIWARE Big Bang の tar.gz ファイルをダウンロードします。
 
 ```bash
-curl -sL https://github.com/lets-fiware/FIWARE-Big-Bang/archive/refs/tags/v0.28.0.tar.gz | tar zxf -
+curl -sL https://github.com/lets-fiware/FIWARE-Big-Bang/archive/refs/tags/v0.29.0.tar.gz | tar zxf -
 ```
 
-`FIWARE-Big-Bang-0.28.0` ディレクトリに移動します。
+`FIWARE-Big-Bang-0.29.0` ディレクトリに移動します。
 
 ```bash
-cd FIWARE-Big-Bang-0.28.0/
+cd FIWARE-Big-Bang-0.29.0/
 ```
 
 独自のドメイン名とパブリック IP アドレスを指定して、`lets-fiware.sh` スクリプトを実行します。

--- a/lets-fiware.sh
+++ b/lets-fiware.sh
@@ -28,7 +28,7 @@
 
 set -Ceuo pipefail
 
-VERSION=0.28.0-next
+VERSION=0.29.0
 
 #
 # Syslog info


### PR DESCRIPTION
## Proposed changes

This PR bumps FIWARE Big Bang version from 0.28.0-next -> 0.29.0.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update docker image version of FIWARE GE.
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/FIWARE-Big-Bang-individual-cla.pdf)
-   [X] I have updated the change log (CHANGELOG.md)
-   [X] I send this pull request to the `v0.28.0-next` branch.
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...
