### PR TITLE
Fix nifi.properties not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## FIWARE Big Bang v0.30.0-next
 
+-   Fix nifi.properties not found (#295)
+
 ## FIWARE Big Bang v0.30.0 - 04 August, 2023
 
 -   Fix issue that Keyrock fails to create application with openid (#292)


### PR DESCRIPTION
## Proposed changes

This PR fixes nifi.properties not found.

[7128](https://github.com/lets-fiware/FIWARE-Big-Bang/actions/runs/5761256736/job/15618750585?pr=292#step:3:7129)Status: Downloaded newer image for ging/fiware-draco:2.1.0 
[7129](https://github.com/lets-fiware/FIWARE-Big-Bang/actions/runs/5761256736/job/15618750585?pr=292#step:3:7130)sed: can't read /home/runner/work/FIWARE-Big-Bang/FIWARE-Big-Bang/config/draco/cert/nifi.properties: No such file or directory
## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update docker image version of FIWARE GE.
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/FIWARE-Big-Bang-individual-cla.pdf)
-   [X] I have updated the change log (CHANGELOG.md)
-   [X] I send this pull request to the `v0.30.0-next` branch.
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A