### PR TITLE
Fix command not found on Ubuntu 22.04 Minimal Server Installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## FIWARE Big Bang v0.30.0-next
 
+-   Fix command not found on Ubuntu 22.04 Minimal Server Installation (#296)
 -   Fix nifi.properties not found (#295)
 
 ## FIWARE Big Bang v0.30.0 - 04 August, 2023

--- a/lets-fiware.sh
+++ b/lets-fiware.sh
@@ -691,7 +691,7 @@ install_commands_ubuntu() {
   logging_info "${FUNCNAME[0]}"
 
   ${APT} update
-  ${APT} install -y curl pwgen jq make zip
+  ${APT} install -y curl pwgen jq make zip rsyslog host
 }
 
 #
@@ -711,12 +711,18 @@ install_commands() {
   logging_info "${FUNCNAME[0]}"
 
   update=false
-  for cmd in curl pwgen jq zip
+  for cmd in curl pwgen jq zip host
   do
     if ! type "${cmd}" >/dev/null 2>&1; then
         update=true
     fi
   done
+
+  if [ "${DISTRO}" == "Ubuntu" ]; then
+    if ! [ -e /etc/rsyslog.conf ]; then
+        update=true
+    fi
+  fi
 
   if "${update}"; then
     case "${DISTRO}" in


### PR DESCRIPTION
## Proposed changes

This PR fixes command not found on Ubuntu 22.04 Minimal Server Installation.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update docker image version of FIWARE GE.
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/FIWARE-Big-Bang-individual-cla.pdf)
-   [X] I have updated the change log (CHANGELOG.md)
-   [X] I send this pull request to the `v0.30.0-next` branch.
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A