### PR TITLE
Avoid waiting for operator intervention at apt install on Ubuntu 22.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## FIWARE Big Bang v0.30.0-next
 
+-   Avoid waiting for operator intervention at apt install on Ubuntu 22.04 (#297)
 -   Fix command not found on Ubuntu 22.04 Minimal Server Installation (#296)
 -   Fix nifi.properties not found (#295)
 

--- a/lets-fiware.sh
+++ b/lets-fiware.sh
@@ -690,6 +690,9 @@ check_machine() {
 install_commands_ubuntu() {
   logging_info "${FUNCNAME[0]}"
 
+  if [ -e /etc/needrestart/conf.d ]; then
+    echo "\$nrconf{restart} = 'a';" | ${SUDO} tee /etc/needrestart/conf.d/50local.conf > /dev/null
+  fi
   ${APT} update
   ${APT} install -y curl pwgen jq make zip rsyslog host
 }

--- a/tests/script/coverage.sh
+++ b/tests/script/coverage.sh
@@ -290,6 +290,8 @@ install_test3() {
 
   sleep 5
 
+  sudo mkdir -p /etc/needrestart/conf.d
+
   git checkout config.sh
 
   sed -i -e "s/^\(CERT_REVOKE=\).*/\1true/" config.sh


### PR DESCRIPTION
## Proposed changes

This PR avoids waiting for operator intervention at apt install on Ubuntu 22.04.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update docker image version of FIWARE GE.
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/FIWARE-Big-Bang-individual-cla.pdf)
-   [X] I have updated the change log (CHANGELOG.md)
-   [X] I send this pull request to the `v0.30.0-next` branch.
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A