### PR TITLE
Clarifies instance number variable, fixes #373

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -312,6 +312,7 @@ NODE_RED=
 
 # Node-RED multi instance
 # Number of Node-RED instance. default: 1
+#   Must be between 2 and 20 when specified
 NODE_RED_INSTANCE_NUMBER=
 
 # username for Node-RED instance. default: node-red

--- a/config.sh
+++ b/config.sh
@@ -312,7 +312,7 @@ NODE_RED=
 
 # Node-RED multi instance
 # Number of Node-RED instance. default: 1
-#   Must be between 2 and 20 when specified
+# Must be between 2 and 20 when specified
 NODE_RED_INSTANCE_NUMBER=
 
 # username for Node-RED instance. default: node-red


### PR DESCRIPTION
## Proposed changes

This PR clarifies, that variable `NODE_RED_INSTANCE_NUMBER=` must be between `2` and `20` or left empty in order to apply the default value of `1`.

This makes it be inline with the error message: https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/lets-fiware.sh#L372-L389

This fixes #373 .

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   \[x\] Bugfix (non-breaking change which fixes an issue)
-   \[ \] New feature (non-breaking change which adds functionality)
-   \[ \] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   \[ \] Update docker image version of FIWARE GE.
-   \[x\] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   \[x\] I have read the [CONTRIBUTING](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/CONTRIBUTING.md) doc
-   \[x\] I have signed the [CLA](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/FIWARE-Big-Bang-individual-cla.pdf)
-   \[ \] I have updated the change log (CHANGELOG.md)
-   \[x\] I send this pull request to the `v0.37.0-next` branch.
-   \[ \] I have added tests that prove my fix is effective or that my feature works
-   \[ \] I have added necessary documentation (if appropriate)
-   \[ \] Any dependent changes have been merged and published in downstream modules

## Further comments

This is probably the easiest "fix" to prevent users to specify `1` and get an error.
