### PR TITLE
Add cross-origin resource sharing for Orion (#394)

### DIFF
--- a/.config.sh
+++ b/.config.sh
@@ -51,6 +51,28 @@ ORION_EXPOSE_PORT=
 # Enable cross-origin resource sharing (CORS) Default: false
 ORION_CORS=
 
+# Set Access-Control-Allow-Origin header for CORS
+#   Default: *
+set -f
+ORION_ACCESS_CONTROL_ALLOW_ORIGIN=
+set +f
+
+# Set Access-Control-Allow-Methods header for CORS
+#   Default: 'GET, POST, OPTIONS, DELETE, PUT, PATCH'
+ORION_ACCESS_CONTROL_ALLOW_METHODS=
+
+# Set Access-Control-Allow-Headers header for CORS
+#   Default: 'Origin, Content-Type, Accept, Authorization, X-Requested-With, fiware-service, fiware-servicepath'
+ORION_ACCESS_CONTROL_ALLOW_HEADERS=
+
+# Set Access-Control-Expose-Headers header for CORS
+#   Default: 'location, fiware-correlator'
+ORION_CONTROL_EXPOSE_HEADERS=
+
+# Set Access-Control-Max-Age header for CORS
+#   Default: 7200
+ORION_ACCESS_CONTROL_MAX_AGE=
+
 # Docker image for Orion
 IMAGE_ORION=telefonicaiot/fiware-orion:4.0.0
 

--- a/.config.sh
+++ b/.config.sh
@@ -52,7 +52,7 @@ ORION_EXPOSE_PORT=
 ORION_CORS=
 
 # Set Access-Control-Allow-Origin header for CORS
-#   Default: *
+#   Default: '*'
 set -f
 ORION_ACCESS_CONTROL_ALLOW_ORIGIN=
 set +f

--- a/.config.sh
+++ b/.config.sh
@@ -48,6 +48,9 @@ ORION=orion
 # Expose port 1026 (none, local, all) Default: none
 ORION_EXPOSE_PORT=
 
+# Enable cross-origin resource sharing (CORS) Default: false
+ORION_CORS=
+
 # Docker image for Orion
 IMAGE_ORION=telefonicaiot/fiware-orion:4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## FIWARE Big Bang v0.39.0-next
 
+-   Add cross-origin resource sharing for Orion (#394)
 -   Fix maintenance script (#393)
 
 ## FIWARE Big Bang v0.39.0 - 09 June, 2024

--- a/config.sh
+++ b/config.sh
@@ -51,6 +51,28 @@ ORION_EXPOSE_PORT=
 # Enable cross-origin resource sharing (CORS) Default: false
 ORION_CORS=
 
+# Set Access-Control-Allow-Origin header for CORS
+#   Default: *
+set -f
+ORION_ACCESS_CONTROL_ALLOW_ORIGIN=
+set +f
+
+# Set Access-Control-Allow-Methods header for CORS
+#   Default: 'GET, POST, OPTIONS, DELETE, PUT, PATCH'
+ORION_ACCESS_CONTROL_ALLOW_METHODS=
+
+# Set Access-Control-Allow-Headers header for CORS
+#   Default: 'Origin, Content-Type, Accept, Authorization, X-Requested-With, fiware-service, fiware-servicepath'
+ORION_ACCESS_CONTROL_ALLOW_HEADERS=
+
+# Set Access-Control-Expose-Headers header for CORS
+#   Default: 'location, fiware-correlator'
+ORION_CONTROL_EXPOSE_HEADERS=
+
+# Set Access-Control-Max-Age header for CORS
+#   Default: 7200
+ORION_ACCESS_CONTROL_MAX_AGE=
+
 # Docker image for Orion
 IMAGE_ORION=telefonicaiot/fiware-orion:4.0.0
 

--- a/config.sh
+++ b/config.sh
@@ -52,7 +52,7 @@ ORION_EXPOSE_PORT=
 ORION_CORS=
 
 # Set Access-Control-Allow-Origin header for CORS
-#   Default: *
+#   Default: '*'
 set -f
 ORION_ACCESS_CONTROL_ALLOW_ORIGIN=
 set +f

--- a/config.sh
+++ b/config.sh
@@ -48,6 +48,9 @@ ORION=orion
 # Expose port 1026 (none, local, all) Default: none
 ORION_EXPOSE_PORT=
 
+# Enable cross-origin resource sharing (CORS) Default: false
+ORION_CORS=
+
 # Docker image for Orion
 IMAGE_ORION=telefonicaiot/fiware-orion:4.0.0
 

--- a/docs/en/installation/orion.md
+++ b/docs/en/installation/orion.md
@@ -15,11 +15,16 @@
 
 You can specify configurations by editing the `config.sh` file.
 
-| Variable name       | Description                                 | Default value |
-| ------------------- | ------------------------------------------- | ------------- |
-| ORION               | A sub-domain name of Orion.                 | orion         |
-| ORION\_EXPOSE\_PORT | Expose port 1026. (none, local, all)        | none          |
-| ORION\_CORS         | Enable cross-origin resource sharing (CORS) | false         |
+| Variable name                          | Description                                       | Default value                                                                                       |
+| -------------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| ORION                                  | A sub-domain name of Orion.                       | orion                                                                                               |
+| ORION\_EXPOSE\_PORT                    | Expose port 1026. (none, local, all)              | none                                                                                                |
+| ORION\_CORS                            | Enable cross-origin resource sharing (CORS)       | false                                                                                               |
+| ORION\_ACCESS\_CONTROL\_ALLOW\_ORIGIN  | Set Access-Control-Allow-Origin header for CORS   | '\*'                                                                                                |
+| ORION\_ACCESS\_CONTROL\_ALLOW\_METHODS | Set Access-Control-Allow-Methods header for CORS  | 'GET, POST, OPTIONS, DELETE, PUT, PATCH'                                                            |
+| ORION\_ACCESS\_CONTROL\_ALLOW\_HEADERS | Set Access-Control-Allow-Headers header for CORS  | 'Origin, Content-Type, Accept, Authorization, X-Requested-With, fiware-service, fiware-servicepath' |
+| ORION\_CONTROL\_EXPOSE\_HEADERS        | Set Access-Control-Expose-Headers header for CORS | 'location, fiware-correlator'                                                                       |
+| ORION\_ACCESS\_CONTROL\_MAX\_AGE       | Set Access-Control-Max-Age header for CORS        | 7200                                                                                                |
 
 ## How to setup
 

--- a/docs/en/installation/orion.md
+++ b/docs/en/installation/orion.md
@@ -15,10 +15,11 @@
 
 You can specify configurations by editing the `config.sh` file.
 
-| Variable name       | Description                           | Default value |
-| ------------------- | ------------------------------------- | ------------- |
-| ORION               | A sub-domain name of Orion.           | orion         | 
-| ORION\_EXPOSE\_PORT | Expose port 1026. (none, local, all)  | none          |
+| Variable name       | Description                                 | Default value |
+| ------------------- | ------------------------------------------- | ------------- |
+| ORION               | A sub-domain name of Orion.                 | orion         |
+| ORION\_EXPOSE\_PORT | Expose port 1026. (none, local, all)        | none          |
+| ORION\_CORS         | Enable cross-origin resource sharing (CORS) | false         |
 
 ## How to setup
 

--- a/docs/ja/installation/orion.md
+++ b/docs/ja/installation/orion.md
@@ -17,11 +17,16 @@
 
 `config.sh` ファイルを編集して構成を指定できます。
 
-| 変数名              | 説明                                                 | 既定値 |
-| ------------------- | ---------------------------------------------------- | ------ |
-| ORION               | Orion のサブドメイン名                               | orion  | 
-| ORION\_EXPOSE\_PORT | Orion のポート 1026 を公開。(none, local または all) | none   |
-| ORION\_CORS         | Cross-origin resource sharing (CORS) を有効化        | false  |
+| 変数名                                 | 説明                                                 | 既定値                                                                                              |
+| -------------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| ORION                                  | Orion のサブドメイン名                               | orion                                                                                               |
+| ORION\_EXPOSE\_PORT                    | Orion のポート 1026 を公開。(none, local または all) | none                                                                                                |
+| ORION\_CORS                            | Cross-origin resource sharing (CORS) を有効化        | false                                                                                               |
+| ORION\_ACCESS\_CONTROL\_ALLOW\_ORIGIN  | CORS の Access-Control-Allow-Origin ヘッダを設定     | '\*'                                                                                                |
+| ORION\_ACCESS\_CONTROL\_ALLOW\_METHODS | CORS の Access-Control-Allow-Methods ヘッダを設定    | 'GET, POST, OPTIONS, DELETE, PUT, PATCH'                                                            |
+| ORION\_ACCESS\_CONTROL\_ALLOW\_HEADERS | CORS の Access-Control-Allow-Headers ヘッダを設定    | 'Origin, Content-Type, Accept, Authorization, X-Requested-With, fiware-service, fiware-servicepath' |
+| ORION\_CONTROL\_EXPOSE\_HEADERS        | CORS の Access-Control-Expose-Headers ヘッダを設定   | 'location, fiware-correlator'                                                                       |
+| ORION\_ACCESS\_CONTROL\_MAX\_AGE       | CORS の Access-Control-Max-Age header ヘッダを設定   | 7200                                                                                                |
 
 <a name="how-to-setup"></a>
 

--- a/docs/ja/installation/orion.md
+++ b/docs/ja/installation/orion.md
@@ -21,6 +21,7 @@
 | ------------------- | ---------------------------------------------------- | ------ |
 | ORION               | Orion のサブドメイン名                               | orion  | 
 | ORION\_EXPOSE\_PORT | Orion のポート 1026 を公開。(none, local または all) | none   |
+| ORION\_CORS         | Cross-origin resource sharing (CORS) を有効化        | false  |
 
 <a name="how-to-setup"></a>
 

--- a/lets-fiware.sh
+++ b/lets-fiware.sh
@@ -1963,8 +1963,27 @@ EOF
   create_nginx_conf "${ORION}" "nginx-orion"
 
   if "${ORION_CORS}"; then
-    sed -i "/__NGINX_ORION_CORS_HEADERS__/r ${SETUP_DIR}/template/nginx/nginx-orion-cors-headers" "${NGINX_SITES}/${ORION}"
-    sed -i "/__NGINX_ORION_CORS_REQUEST_METHOD__/r ${SETUP_DIR}/template/nginx/nginx-orion-cors-request-method" "${NGINX_SITES}/${ORION}"
+    set -f
+    if [ -z ${ORION_ACCESS_CONTROL_ALLOW_ORIGIN} ]; then
+      ORION_ACCESS_CONTROL_ALLOW_ORIGIN="'*'"
+    fi
+    : ${ORION_ACCESS_CONTROL_ALLOW_METHODS:="'GET, POST, OPTIONS, DELETE, PUT, PATCH'"}
+    : ${ORION_ACCESS_CONTROL_ALLOW_HEADERS:="'Origin, Content-Type, Accept, Authorization, X-Requested-With, fiware-service, fiware-servicepath'"}
+    : ${ORION_CONTROL_EXPOSE_HEADERS:="'location, fiware-correlator'"}
+    : ${ORION_ACCESS_CONTROL_MAX_AGE:=7200}
+
+    sed -i \
+        -e "/__NGINX_ORION_CORS_HEADERS__/r ${SETUP_DIR}/template/nginx/nginx-orion-cors-headers" \
+        -e "/__NGINX_ORION_CORS_REQUEST_METHOD__/r ${SETUP_DIR}/template/nginx/nginx-orion-cors-request-method" \
+        "${NGINX_SITES}/${ORION}"
+    sed -i \
+        -e "s/ORION_ACCESS_CONTROL_ALLOW_ORIGIN/${ORION_ACCESS_CONTROL_ALLOW_ORIGIN}/" \
+        -e "s/ORION_ACCESS_CONTROL_ALLOW_METHODS/${ORION_ACCESS_CONTROL_ALLOW_METHODS}/" \
+        -e "s/ORION_ACCESS_CONTROL_ALLOW_HEADERS/${ORION_ACCESS_CONTROL_ALLOW_HEADERS}/" \
+        -e "s/ORION_CONTROL_EXPOSE_HEADERS/${ORION_CONTROL_EXPOSE_HEADERS}/" \
+        -e "s/ORION_ACCESS_CONTROL_MAX_AGE/${ORION_ACCESS_CONTROL_MAX_AGE}/" \
+        "${NGINX_SITES}/${ORION}"
+    set +f
   fi
 
   add_nginx_depends_on "orion"

--- a/lets-fiware.sh
+++ b/lets-fiware.sh
@@ -124,6 +124,10 @@ set_default_values() {
     ORION_EXPOSE_PORT=none
   fi
 
+  if [ -z "${ORION_CORS=}" ]; then
+    ORION_CORS=false
+  fi
+
   if [ -z "${ORION_LD_EXPOSE_PORT}" ]; then
     ORION_LD_EXPOSE_PORT=none
   fi
@@ -1958,6 +1962,11 @@ EOF
 
   create_nginx_conf "${ORION}" "nginx-orion"
 
+  if "${ORION_CORS}"; then
+    sed -i "/__NGINX_ORION_CORS_HEADERS__/r ${SETUP_DIR}/template/nginx/nginx-orion-cors-headers" "${NGINX_SITES}/${ORION}"
+    sed -i "/__NGINX_ORION_CORS_REQUEST_METHOD__/r ${SETUP_DIR}/template/nginx/nginx-orion-cors-request-method" "${NGINX_SITES}/${ORION}"
+  fi
+
   add_nginx_depends_on "orion"
 
   add_rsyslog_conf "orion"
@@ -3648,7 +3657,7 @@ setup_end() {
     sed -i -e "/# __NGINX_KEYROCK__/d" "${NGINX_SITES}/${KEYROCK}"
   fi
   if [ -n "${ORION}" ]; then
-    sed -i -e "/# __NGINX_ORION__/d" "${NGINX_SITES}/${ORION}"
+    sed -i -e "/# __NGINX_ORION_/d" "${NGINX_SITES}/${ORION}"
   fi
   if [ -n "${ORION_LD}" ]; then
     sed -i -e "/# __NGINX_ORION_LD__/d" "${NGINX_SITES}/${ORION_LD}"

--- a/setup/template/nginx/nginx-orion
+++ b/setup/template/nginx/nginx-orion
@@ -31,7 +31,9 @@ server {
   add_header              Front-End-Https   on;
   add_header              Strict-Transport-Security 'max-age=15768000; includeSubdomains; always';
 
+  # __NGINX_ORION_CORS_HEADERS__
   location / {
+    # __NGINX_ORION_CORS_REQUEST_METHOD__
     set $req_uri "$uri";
     auth_request /_check_oauth2_token;
 

--- a/setup/template/nginx/nginx-orion-cors-headers
+++ b/setup/template/nginx/nginx-orion-cors-headers
@@ -1,6 +1,6 @@
   # Add CORS Headers
-  add_header 'Access-Control-Allow-Origin' '*' always;
-  add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, DELETE, PUT, PATCH' always;
-  add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization, X-Requested-With, fiware-service, fiware-servicepath' always;
-  add_header 'Access-Control-Expose-Headers' 'location, fiware-correlator' always;
+  add_header 'Access-Control-Allow-Origin' ORION_ACCESS_CONTROL_ALLOW_ORIGIN;
+  add_header 'Access-Control-Allow-Methods' ORION_ACCESS_CONTROL_ALLOW_METHODS;
+  add_header 'Access-Control-Allow-Headers' ORION_ACCESS_CONTROL_ALLOW_HEADERS;
+  add_header 'Access-Control-Expose-Headers' ORION_CONTROL_EXPOSE_HEADERS;
 

--- a/setup/template/nginx/nginx-orion-cors-headers
+++ b/setup/template/nginx/nginx-orion-cors-headers
@@ -1,0 +1,6 @@
+  # Add CORS Headers
+  add_header 'Access-Control-Allow-Origin' '*' always;
+  add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, DELETE, PUT, PATCH' always;
+  add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization, X-Requested-With, fiware-service, fiware-servicepath' always;
+  add_header 'Access-Control-Expose-Headers' 'location, fiware-correlator' always;
+

--- a/setup/template/nginx/nginx-orion-cors-request-method
+++ b/setup/template/nginx/nginx-orion-cors-request-method
@@ -1,9 +1,9 @@
     if ($request_method = 'OPTIONS') {
-      add_header 'Access-Control-Allow-Origin' '*' always;
-      add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, DELETE, PUT, PATCH' always;
-      add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization, X-Requested-With, fiware-service, fiware-servicepath' always;
-      add_header 'Access-Control-Expose-Headers' 'location, fiware-correlator' always;
-      add_header 'Access-Control-Max-Age' 1728000;
+      add_header 'Access-Control-Allow-Origin' ORION_ACCESS_CONTROL_ALLOW_ORIGIN;
+      add_header 'Access-Control-Allow-Methods' ORION_ACCESS_CONTROL_ALLOW_METHODS;
+      add_header 'Access-Control-Allow-Headers' ORION_ACCESS_CONTROL_ALLOW_HEADERS;
+      add_header 'Access-Control-Expose-Headers' ORION_CONTROL_EXPOSE_HEADERS;
+      add_header 'Access-Control-Max-Age' ORION_ACCESS_CONTROL_MAX_AGE;
       add_header 'Content-Type' 'text/plain charset=UTF-8';
       add_header 'Content-Length' 0;
       return 204;

--- a/setup/template/nginx/nginx-orion-cors-request-method
+++ b/setup/template/nginx/nginx-orion-cors-request-method
@@ -1,0 +1,11 @@
+    if ($request_method = 'OPTIONS') {
+      add_header 'Access-Control-Allow-Origin' '*' always;
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, DELETE, PUT, PATCH' always;
+      add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization, X-Requested-With, fiware-service, fiware-servicepath' always;
+      add_header 'Access-Control-Expose-Headers' 'location, fiware-correlator' always;
+      add_header 'Access-Control-Max-Age' 1728000;
+      add_header 'Content-Type' 'text/plain charset=UTF-8';
+      add_header 'Content-Length' 0;
+      return 204;
+    }
+

--- a/tests/script/coverage.sh
+++ b/tests/script/coverage.sh
@@ -253,6 +253,7 @@ install_test1() {
   sudo apt remove -y rsyslog
 
   sed -i -e "s/^\(ORION_EXPOSE_PORT=\).*/\1local/" config.sh
+  sed -i -e "s/^\(ORION_CORS=\).*/\1true/" config.sh
   sed -i -e "s/^\(CYGNUS=\).*/\1cygnus/" config.sh
   sed -i -e "s/^\(COMET=\).*/\1comet/" config.sh
   sed -i -e "s/^\(QUANTUMLEAP=\).*/\1quantumleap/" config.sh


### PR DESCRIPTION
## Proposed changes

This PR adds cross-origin resource sharing for Orion.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   \[ \] Bugfix (non-breaking change which fixes an issue)
-   \[X\] New feature (non-breaking change which adds functionality)
-   \[ \] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   \[ \] Update docker image version of FIWARE GE.
-   \[ \] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   \[X\] I have read the [CONTRIBUTING](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/CONTRIBUTING.md) doc
-   \[ \] I have signed the [CLA](https://github.com/lets-fiware/FIWARE-Big-Bang/blob/main/FIWARE-Big-Bang-individual-cla.pdf)
-   \[X\] I have updated the change log (CHANGELOG.md)
-   \[X\] I send this pull request to the `v0.39.0-next` branch.
-   \[X\] I have added tests that prove my fix is effective or that my feature works
-   \[X\] I have added necessary documentation (if appropriate)
-   \[ \] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...
